### PR TITLE
Fixing inline requests for `snowcrash` usage with MSVC

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #if defined(_MSC_VER)
 #define __attribute__(x)
-#define inline
+#define inline __inline
 #endif
 
 typedef enum {


### PR DESCRIPTION
To resolve linking problem on `snowcrash`.

CC. @zdne.
