### PR TITLE
Fix computation of continuos range length

### DIFF
--- a/src/src_map.c
+++ b/src/src_map.c
@@ -125,7 +125,7 @@ src_map_append(src_map *map, const range *r)
         /* check continuous range */
         range *last_range = (range *)map->item[map->size - 1];
         if (r->loc <= last_range->loc + last_range->len) {
-            last_range->len += r->len - (last_range->len - r->loc);
+            last_range->len += r->len - (last_range->loc + last_range->len - r->loc);
             return;
         }
     }


### PR DESCRIPTION
The computation of final length when joining a continuous block has been seriously flawed. This commit should correct the computation.
Example case where the wrong computation has backfired is a list item with lazily nested paragraphs:

```
+   Lorem ipsum
dolor sit amet

consectetur
adipiscing elit
```
