### PR TITLE
Allow return source map for zero length blocks (avoid assert invoke)

### DIFF
--- a/src/src_map.c
+++ b/src/src_map.c
@@ -155,6 +155,9 @@ src_map_location(const src_map *map, size_t index)
         cur += it->len;
     }
 
+    if (index >= cur)
+      return cur;
+
  	assert(0);
     return -1;
 }


### PR DESCRIPTION
Fix assert invoke while "quota block" has zero length

Tests are implemented in related commit into https://github.com/apiaryio/markdown-parser