### PR TITLE
Move license from README to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+`Sundown` is based on the original Upskirt parser by Natacha Porté, with many
+additions by Vicent Marti (@vmg) and contributions from the following authors:
+
+    Ben Noordhuis, Bruno Michel, Joseph Koshy, Krzysztof Kowalczyk, Samuel
+    Bronson, Shuhei Tanuma
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -61,15 +61,6 @@ Features
 	`Sundown` is a zero-dependency library composed of 3 `.c` files and their headers.
 	No dependencies, no bullshit. Only standard C99 that builds everywhere.
 
-Credits
--------
-
-`Sundown` is based on the original Upskirt parser by Natacha Porté, with many additions
-by Vicent Marti (@vmg) and contributions from the following authors:
-
-	Ben Noordhuis, Bruno Michel, Joseph Koshy, Krzysztof Kowalczyk, Samuel Bronson,
-	Shuhei Tanuma
-
 Bindings
 --------
 
@@ -120,21 +111,6 @@ If you are hardcore, you can use the included `Makefile` to build `Sundown` into
 library, or to build the sample `sundown` executable, which is just a commandline
 Markdown to XHTML parser. (If gcc gives you grief about `-fPIC`, e.g. with MinGW, try
 `make MFLAGS=` instead of just `make`.)
-
-License
--------
-
-Permission to use, copy, modify, and distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 <!-- Local Variables: -->
 <!-- fill-column: 89 -->


### PR DESCRIPTION
LICENSE files are more standardised and easier to integrate into other tooling. This is part of a larger PR to expose the licenses of third party dependencies vendored into our Drafter, Protagonist and Drafter.js projects.

This is a dependency for https://github.com/apiaryio/drafter/pull/732